### PR TITLE
Simplify irssi hiera

### DIFF
--- a/modules/irssi/README.md
+++ b/modules/irssi/README.md
@@ -14,15 +14,14 @@ Valid keys for that hash:
 * nick\_hashed\_password (string) - Your hashed bitlbee identify password. You
   can generate a new one by running `bitlbee -x hash $new_password`. See [wiki
 page](http://wiki.bitlbee.org/DecodingPasswords) for more details.
-* accounts (hash) - see `accounts` section
-* channels (hash) - see `channels` section
+* accounts (array) - see `accounts` section
+* channels (array) - see `channels` section
 
 
 irssi::bitlbee\_nick\_instances - accounts
 ----------------------------------------
 
-Keys are only used to document.
-Each value is a hash that populates a single
+Each element is a hash that populates a single
 user:account node. Available keys in this hash:
 
 * `account_options` (hash) - populates attributes of user:accounts xml
@@ -51,8 +50,7 @@ irssi::bitlbee\_nick\_instances - channels
 
 Add an entry to this hash for each chatroom you care about.
 
-Keys are only used to document.
-Each value is a hash that populate a single
+Each element is a hash that populate a single
 user:channel xml node. Available keys in this hash:
 
 * `name` (string) - populates the name attribute on the user:channel node.

--- a/modules/irssi/README.md
+++ b/modules/irssi/README.md
@@ -83,13 +83,13 @@ Available settings:
 * `irssi_group` (string): Group used to run irssi
 * `settings` (hash): login credentials and log settings. See `im::instances -
   settings`
-* `chatnets` (hash): some interesting channels on different networks. See
+* `chatnets` (array): some interesting channels on different networks. See
   `im::instances - chatnets`
-* `channels` (hash): channels we care about on each network, autojoin settings.
+* `channels` (array): channels we care about on each network, autojoin settings.
   See `im::instances - channels`
-* `hilights` (hash): words/phrases that will trigger hilights, with their
+* `hilights` (array): words/phrases that will trigger hilights, with their
   corresponding activity color. See `im::instances - hilights`
-* `ignores` (hash): message types that should not be displayed in each channel. See
+* `ignores` (array): message types that should not be displayed in each channel. See
   `im::instances - ignores`
 * `notifies` (hash): people whose coming online should notify us. See
   `im::instances - notifies`
@@ -123,10 +123,11 @@ Valid entries are:
 im::instances - chatnets
 ------------------
 
-Keys are chat network names.
-Values are hashes to configure that chat network.
+Elements are hashes to configure that chat network.
 Configurable settings are:
 
+* `name` (string): chat network name, used in other settings such as
+  `channels`, below.
 * `address` (string): domain, eg `irc.freenode.net`
 * `port` (string): remote port. Eg, `7000` on freenode is for SSL only
 * `use_ssl` (boolean)
@@ -139,8 +140,7 @@ Configurable settings are:
 * `nick` (string): overrides nick from `im::instances - settings`
 * `username` (string): overrides username from `im::instances - settings`
 * `realname` (string): overrides realname from `im::instances - settings`
-* `sasl_auth` (string): An array of single-element key-values for authenticating with
-  NickServ (let's fix this so it's a hash) XXX
+* `sasl_auth` (hash): settings for authenticating with nickserv. Available keys:
     * `username` (string)
     * `passwond` (string)
     * `type` (string): type of auth. Eg, freenode supports 'DH-BLOWFISH' or PLAIN'
@@ -148,13 +148,12 @@ Configurable settings are:
 im::instances - channels
 ------------------
 
-Keys are only used to document.
-Values are hashes to configure each chat network.
+Elements are hashes to configure each chat network.
 Available configuration settings are:
 
 * `name` (string): name of the channel to join
-* `chatnet` (string): which network it's on. Corresponds to a key in
-  `im::instances - chatnets`.
+* `chatnet` (string): which network it's on. Corresponds the name of an
+  entry in `im::instances - chatnets`.
 * `autojoin` (boolean): whether to automatically join this room or not.
 * `password` (string)
 * `botmasks` (string)
@@ -162,8 +161,7 @@ Available configuration settings are:
 im::instances - hilights
 ------------------
 
-Keys are only used to document.
-Values are hashes configuring terms to trigger highlighting.
+Elements are hashes configuring terms to trigger highlighting.
 Available configuration settings are:
 
 * `text` (string): a string that will trigger hilights
@@ -183,8 +181,7 @@ See section 9 of [the irssi manual](http://www.irssi.org/documentation/manual)
 im::instances - ignores
 -----------------
 
-Keys are only used to document.
-Values are hashing configuring the message types that should be ignored in which
+Elements are hashing configuring the message types that should be ignored in which
 channel.
 Valid configurations are:
 

--- a/modules/irssi/manifests/bitlbee_nick_instance.pp
+++ b/modules/irssi/manifests/bitlbee_nick_instance.pp
@@ -6,7 +6,9 @@ define irssi::bitlbee_nick_instance (
   $bitlbee_group = 'bitlbee',
 ) {
 
-  file {"/var/lib/bitlbee/${title}.xml":
+  $nick = $title
+
+  file {"/var/lib/bitlbee/${nick}.xml":
     ensure  => file,
     content => template('irssi/bitlbee-nick.xml.erb'),
     owner   => $bitlbee_user,

--- a/modules/irssi/templates/bitlbee-nick.xml.erb
+++ b/modules/irssi/templates/bitlbee-nick.xml.erb
@@ -1,21 +1,21 @@
-<user nick="<%= @title %>" password="<%= @nick_hashed_password %>" version="1">
+<user nick="<%= @nick %>" password="<%= @nick_hashed_password %>" version="1">
   <setting name="last_version">197121</setting>
   <setting name="save_on_quit">false</setting>
-  <% @accounts.each do |k, v| -%>
+  <% @accounts.each do |account| -%>
     <account
-      <% v['account_options'].each do |mk, mv| -%>
-        <%= mk %>="<%= mv %>"
+      <% account['account_options'].each do |option, value| -%>
+        <%= option %>="<%= value %>"
       <% end -%>
       >
-  <% v['settings'].each do |sk, sv| -%>
-    <setting name="<%= sk %>"><%= sv %></setting>
+  <% account['settings'].each do |setting, value| -%>
+    <setting name="<%= setting %>"><%= value %></setting>
   <% end -%>
   </account>
   <% end -%>
-  <% @channels.each do |k, v| -%>
-  <channel name="<%= v['name'] %>" type="<%= v['type'] %>">
-      <% v['settings'].each do |mk, mv| -%>
-    <setting name="<%= mk %>"><%= mv %></setting>
+  <% @channels.each do |channel| -%>
+  <channel name="<%= channel['name'] %>" type="<%= channel['type'] %>">
+      <% channel['settings'].each do |setting, value| -%>
+    <setting name="<%= setting %>"><%= value %></setting>
       <% end -%>
   </channel>
   <% end -%>

--- a/modules/irssi/templates/config.erb
+++ b/modules/irssi/templates/config.erb
@@ -1,44 +1,44 @@
 servers = (
-  <% @chatnets.each do |k, v| -%>
+  <% @chatnets.each do |chatnet| -%>
   {
-    address = "<%= v['address'] %>";
-    chatnet = "<%= k %>";
-    port = "<%= v['port'] %>";
-    use_ssl = "<%= v['use_ssl'] %>";
-    ssl_verify = "<%= v['ssl_verify'] %>";
-    autoconnect = "<%= v['autoconnect'] %>";
-    <% if v['ssl_capath'] -%>
-    ssl_capath = "<%= v['ssl_capath'] %>";
+    address = "<%= chatnet['address'] %>";
+    chatnet = "<%= chatnet['name'] %>";
+    port = "<%= chatnet['port'] %>";
+    use_ssl = "<%= chatnet['use_ssl'] %>";
+    ssl_verify = "<%= chatnet['ssl_verify'] %>";
+    autoconnect = "<%= chatnet['autoconnect'] %>";
+    <% if chatnet['ssl_capath'] -%>
+    ssl_capath = "<%= chatnet['ssl_capath'] %>";
     <% end -%>
-    <% if v['password'] -%>
-    password = "<%= v['password'] %>";
+    <% if chatnet['password'] -%>
+    password = "<%= chatnet['password'] %>";
     <% end -%>
   },
   <% end -%>
 );
 
 chatnets = {
-  <% @chatnets.each do |k, v| -%>
-  <%= k %> = {
-    type = "<%= v['type'] %>";
-    <% if v['nick'] %>
-    nick = "<%= v['nick'] %>";
+  <% @chatnets.each do |chatnet| -%>
+  <%= chatnet['name'] %> = {
+    type = "<%= chatnet['type'] %>";
+    <% if chatnet['nick'] %>
+    nick = "<%= chatnet['nick'] %>";
     <% end -%>
-    <% if v['username'] %>
-    username = "<%= v['username'] %>";
+    <% if chatnet['username'] %>
+    username = "<%= chatnet['username'] %>";
     <% end -%>
-    <% if v['realname'] %>
-    realname = "<%= v['realname'] %>";
+    <% if chatnet['realname'] %>
+    realname = "<%= chatnet['realname'] %>";
     <% end -%>
   };
   <% end -%>
 };
 
 channels = (
-  <% @channels.each do |k, v| -%>
+  <% @channels.each do |channel| -%>
     {
-  <% v.each do |mk, mv| -%>
-    <%= mk %> = "<%= mv %>";
+  <% channel.each do |setting, value| -%>
+    <%= setting %> = "<%= value %>";
   <% end -%>
     },
   <% end -%>
@@ -92,8 +92,8 @@ aliases = {
   ATAG = "WINDOW SERVER";
   UNSET = "set -clear";
   RESET = "set -default";
-  <% @aliases.each do |k, v| -%>
-  <%= k %> = "<%= v %>";
+  <% @aliases.each do |shortcut, command| -%>
+  <%= shortcut %> = "<%= command %>";
   <% end -%>
 };
 
@@ -277,55 +277,55 @@ settings = {
 };
 logs = { };
 windows = {
-  <% @windows.each do |k, v| -%>
-  <%= k %> = {
-    <% if v['immortal'] -%>
-    immortal = "<%= v['immortal'] %>";
+  <% @windows.each do |window_position, settings| -%>
+  <%= window_position %> = {
+    <% if settings['immortal'] -%>
+    immortal = "<%= settings['immortal'] %>";
     <% end -%>
-    name = "<%= v['name'] %>";
-    <% if v['level'] -%>
-    level = "<%= v['level'] %>";
+    name = "<%= settings['name'] %>";
+    <% if settings['level'] -%>
+    level = "<%= settings['level'] %>";
     <% end -%>
-    <% if v['sticky'] -%>
-    sticky = "<%= v['sticky'] %>";
+    <% if settings['sticky'] -%>
+    sticky = "<%= settings['sticky'] %>";
     <% end -%>
-    <% if v['parent'] -%>
-    parent = "<%= v['parent'] %>";
+    <% if settings['parent'] -%>
+    parent = "<%= settings['parent'] %>";
     <% end -%>
   };
   <% end -%>
 };
 hilights = (
-  <% @hilights.each do |k, v| -%>
+  <% @hilights.each do |hilight| -%>
   {
-  <% v.each do |mk, mv| -%>
-    <%= mk %> = "<%= mv %>";
+  <% hilight.each do |setting, value| -%>
+    <%= setting %> = "<%= value %>";
   <% end -%>
   },
   <% end -%>
 );
 ignores = (
-  <% @ignores.each do |k, v| -%>
+  <% @ignores.each do |ignore| -%>
   {
-  <% v.each do |mk, mv| -%>
-    <% if mk == "channels" -%>
-    <%= mk %> = <%= mv %>;
+  <% ignore.each do |setting, value| -%>
+    <% if setting == "channels" -%>
+    <%= setting %> = <%= value %>;
   <% else %>
-    <%= mk %> = "<%= mv %>";
+    <%= setting %> = "<%= value %>";
     <% end -%>
   <% end -%>
   },
   <% end -%>
 );
 notifies = {
-  <% @notifies.each do |k, v| -%>
-  <%= k %> =
+  <% @notifies.each do |mask, settings| -%>
+  <%= mask %> =
   {
-  <% v.each do |mk, mv| -%>
-    <% if mk == "ircnets" -%>
-    <%= mk %> = <%= mv %>;
+  <% settings.each do |setting, value| -%>
+    <% if setting == "ircnets" -%>
+    <%= setting %> = <%= value %>;
   <% else %>
-    <%= mk %> = "<%= mv %>";
+    <%= setting %> = "<%= value %>";
     <% end -%>
   <% end -%>
   };

--- a/modules/irssi/templates/sasl.auth.erb
+++ b/modules/irssi/templates/sasl.auth.erb
@@ -1,5 +1,5 @@
-<% @chatnets.each do |k, v| -%>
-<% if v['sasl_auth'] -%>
-<%= k %>	<%= v['sasl_auth'][0]['username'] %>	<%= v['sasl_auth'][1]['password'] %>	<%= v['sasl_auth'][2]['type'] %>
+<% @chatnets.each do |chatnet| -%>
+<% if chatnet['sasl_auth'] -%>
+<%= chatnet['name'] %>	<%= chatnet['sasl_auth']['username'] %>	<%= chatnet['sasl_auth']['password'] %>	<%= chatnet['sasl_auth']['type'] %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
To make your hiera data match, you need to convert the following into arrays by replacing the key with a "`-`":
- `irssi::bitlbee_nick_instances - accounts`
- `irssi::bitlbee_nick_instances - channels`
- `irssi::instances - channels`
- `irssi::instances - hilights`
- `irssi::instances - ignores`

Additionally,
- Convert `irssi::instances - chatnets` into an array by moving the chatnet key into the chatnet hash under the key "`name`".
- Remove the array-ness of `im::instances - chatnets - sasl_auth` - Keep the `password`, `type` and `username` keys, but remove the "`-`" in front of them.

Once you've done all that, you should see no change when you run puppet with `--noop`.
